### PR TITLE
feat: docker network stats

### DIFF
--- a/config/go.d.conf
+++ b/config/go.d.conf
@@ -90,3 +90,4 @@ modules:
 #  windows: yes
 #  x509check: yes
 #  zookeeper: yes
+# docker_network: yes

--- a/config/go.d/docker_network.conf
+++ b/config/go.d/docker_network.conf
@@ -1,0 +1,11 @@
+## All available configuration options, their descriptions and default values:
+## https://github.com/netdata/go.d.plugin/tree/master/modules/docker
+
+#update_every: 1
+#autodetection_retry: 0
+#priority: 70000
+
+jobs:
+  - name: local
+    address: 'unix:///var/run/docker.sock'
+    timeout: 2

--- a/modules/docker_network/charts.go
+++ b/modules/docker_network/charts.go
@@ -1,0 +1,1 @@
+package docker_network

--- a/modules/docker_network/charts.go
+++ b/modules/docker_network/charts.go
@@ -47,8 +47,8 @@ var (
 		Priority: prioNetworkBytes,
 		Type:     module.Stacked,
 		Dims: module.Dims{
-			{ID: "network_%s_bytes_rx", Name: "received"},
-			{ID: "network_%s_bytes_tx", Name: "sent"},
+			{ID: "container_%s_network_bytes_rx", Name: "received"},
+			{ID: "container_%s_network_bytes_tx", Name: "sent"},
 		},
 	}
 )

--- a/modules/docker_network/charts.go
+++ b/modules/docker_network/charts.go
@@ -10,27 +10,7 @@ const (
 	prioNetworkBytes = module.Priority + iota
 )
 
-var summaryCharts = module.Charts{
-	// These charts will be collected for all of docker
-	// Mostly just aggregate stats
-	networkBytesChart.Copy(),
-}
-
-var (
-	networkBytesChart = module.Chart{
-		ID:       "network_bytes",
-		Title:    "Network bytes",
-		Units:    "bytes/s",
-		Fam:      "network",
-		Ctx:      "docker_net.network_bytes",
-		Priority: prioNetworkBytes,
-		Type:     module.Stacked,
-		Dims: module.Dims{
-			{ID: "network_bytes_rx", Name: "received"},
-			{ID: "network_bytes_tx", Name: "sent"},
-		},
-	}
-)
+var summaryCharts = module.Charts{}
 
 var (
 	containerNetworkChartsTmpl = module.Charts{

--- a/modules/docker_network/charts.go
+++ b/modules/docker_network/charts.go
@@ -1,1 +1,82 @@
 package docker_network
+
+import (
+	"fmt"
+	"github.com/netdata/go.d.plugin/agent/module"
+	"strings"
+)
+
+const (
+	prioNetworkBytes = module.Priority + iota
+)
+
+var summaryCharts = module.Charts{
+	// These charts will be collected for all of docker
+	// Mostly just aggregate stats
+	networkBytesChart.Copy(),
+}
+
+var (
+	networkBytesChart = module.Chart{
+		ID:       "network_bytes",
+		Title:    "Network bytes",
+		Units:    "bytes/s",
+		Fam:      "network",
+		Ctx:      "docker_net.network_bytes",
+		Priority: prioNetworkBytes,
+		Type:     module.Stacked,
+		Dims: module.Dims{
+			{ID: "network_bytes_rx", Name: "received"},
+			{ID: "network_bytes_tx", Name: "sent"},
+		},
+	}
+)
+
+var (
+	containerNetworkChartsTmpl = module.Charts{
+		// These will be collected for each container
+		containerNetworkBytesChartTmpl.Copy(),
+	}
+
+	containerNetworkBytesChartTmpl = module.Chart{
+		ID:       "network_%s_bytes",
+		Title:    "Network bytes",
+		Units:    "bytes/s",
+		Fam:      "network",
+		Ctx:      "docker_net.container_network_bytes",
+		Priority: prioNetworkBytes,
+		Type:     module.Stacked,
+		Dims: module.Dims{
+			{ID: "network_%s_bytes_rx", Name: "received"},
+			{ID: "network_%s_bytes_tx", Name: "sent"},
+		},
+	}
+)
+
+func (d *DockerNetwork) addContainerCharts(name string) {
+	charts := containerNetworkChartsTmpl.Copy()
+	for _, chart := range *charts {
+		chart.ID = fmt.Sprintf(chart.ID, name)
+		chart.Labels = []module.Label{
+			{Key: "container_name", Value: name},
+		}
+		for _, dim := range chart.Dims {
+			dim.ID = fmt.Sprintf(dim.ID, name)
+		}
+	}
+
+	if err := d.Charts().Add(*charts...); err != nil {
+		d.Warning(err)
+	}
+}
+
+func (d *DockerNetwork) removeContainerCharts(name string) {
+	px := fmt.Sprintf("network_%s", name)
+
+	for _, chart := range *d.Charts() {
+		if strings.HasPrefix(chart.ID, px) {
+			chart.MarkRemove()
+			chart.MarkNotCreated()
+		}
+	}
+}

--- a/modules/docker_network/collect.go
+++ b/modules/docker_network/collect.go
@@ -1,0 +1,1 @@
+package docker_network

--- a/modules/docker_network/collect.go
+++ b/modules/docker_network/collect.go
@@ -1,1 +1,110 @@
 package docker_network
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/docker/docker/api/types"
+)
+
+func (d *DockerNetwork) collect() (map[string]int64, error) {
+	if d.client == nil {
+		// Create a new client
+		client, err := d.newClient(d.Config)
+		if err != nil {
+			return nil, err
+		}
+		d.client = client
+	}
+
+	// Make sure we've negotiated the API version
+	if !d.verNegotiated {
+		d.verNegotiated = true
+		d.negotiateAPIVersion()
+	}
+
+	// Defer closing the client
+	defer func() { _ = d.client.Close() }()
+
+	mx := make(map[string]int64)
+
+	// Collect our info
+	if err := d.collectContainers(mx); err != nil {
+		return nil, err
+	}
+
+	return mx, nil
+}
+
+func (d *DockerNetwork) collectContainers(mx map[string]int64) error {
+	// This function will collect all the containers network stats
+
+	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout.Duration)
+	defer cancel()
+
+	// Get all the containers
+	containers, err := d.client.ContainerList(ctx, types.ContainerListOptions{})
+	if err != nil {
+		return err
+	}
+
+	seen := make(map[string]bool)
+
+	// Get the stats for each container
+	for _, container := range containers {
+		stats, err := d.client.ContainerStats(ctx, container.ID, false)
+		if err != nil {
+			return err
+		}
+
+		// This returns a body that's a reader, so we need to read it
+		body := stats.Body
+		defer func() { _ = body.Close() }()
+
+		// Now we can decode the stats
+		var stat types.StatsJSON
+		if err := json.NewDecoder(body).Decode(&stat); err != nil {
+			return err
+		}
+		// We can now get the network stats
+		network := stat.Networks
+		// Now we want the tx and rx bytes
+		txBytes := 0
+		rxBytes := 0
+		// Loop through the networks and add em up
+		for _, net := range network {
+			txBytes += int(net.TxBytes)
+			rxBytes += int(net.RxBytes)
+		}
+		name := stat.Name
+
+		seen[name] = true
+
+		if !d.containers[name] {
+			// Add the container to our charts
+			d.addContainerCharts(name)
+			d.containers[name] = true
+		}
+
+		// Now we create our metrics
+		px := fmt.Sprintf("container_%s_", name)
+		mx[px+"network_bytes_tx"] = int64(txBytes)
+		mx[px+"network_bytes_rx"] = int64(rxBytes)
+	}
+
+	for name := range d.containers {
+		if !seen[name] {
+			delete(d.containers, name)
+			d.removeContainerCharts(name)
+		}
+	}
+
+	return nil
+}
+
+func (d *DockerNetwork) negotiateAPIVersion() {
+	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout.Duration)
+	defer cancel()
+
+	d.client.NegotiateAPIVersion(ctx)
+}

--- a/modules/docker_network/config_schema.json
+++ b/modules/docker_network/config_schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "go.d/docker job configuration schema.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "address": {
+      "type": "string"
+    },
+    "timeout": {
+      "type": [
+        "string",
+        "integer"
+      ]
+    }
+  },
+  "required": [
+    "name",
+    "address"
+  ]
+}

--- a/modules/docker_network/docker_network.go
+++ b/modules/docker_network/docker_network.go
@@ -1,0 +1,111 @@
+package docker_network
+
+import (
+	"context"
+	_ "embed"
+	"github.com/docker/docker/api/types"
+	docker "github.com/docker/docker/client"
+	"github.com/netdata/go.d.plugin/agent/module"
+	"github.com/netdata/go.d.plugin/pkg/web"
+	"time"
+)
+
+//go:embed "config_schema.json"
+var configSchema string
+
+// Our init function registers the module with the agent.
+func init() {
+	module.Register("docker_network", module.Creator{
+		JobConfigSchema: configSchema,
+		Create:          func() module.Module { return New() },
+	})
+}
+
+// New creates a new instance of our module.
+func New() *DockerNetwork {
+	return &DockerNetwork{
+		// This config is only overridden by the config file.
+		Config: Config{
+			Address: docker.DefaultDockerHost,
+			Timeout: web.Duration{Duration: time.Second * 5},
+		},
+		charts: summaryCharts.Copy(), // TODO: Implement summaryCharts
+		newClient: func(cfg Config) (dockerClient, error) {
+			return docker.NewClientWithOpts(docker.WithHost(cfg.Address))
+		},
+		containers: make(map[string]bool),
+	}
+}
+
+type Config struct {
+	Timeout web.Duration `yaml:"timeout"`
+	Address string       `yaml:"address"`
+}
+
+type (
+	DockerNetwork struct {
+		module.Base
+		Config `yaml:",inline"`
+
+		charts *module.Charts
+
+		newClient     func(Config) (dockerClient, error)
+		client        dockerClient
+		verNegotiated bool
+
+		containers map[string]bool
+	}
+	// For our docker client, we use the official docker client library.
+	// We embed the client in our module, so we can easily mock it in our tests.
+	dockerClient interface {
+		NegotiateAPIVersion(ctx context.Context)
+		Info(ctx context.Context) (types.Info, error)
+		// We just need a list of containers and the stats about it
+		ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
+		// TODO: Implement container stats
+		Close() error
+	}
+)
+
+// These are all boilerplate functions that we need to implement for our module.
+
+// Init will initialize our module.
+func (d *DockerNetwork) Init() bool {
+	return true
+}
+
+// Check will check if the module is able to collect metrics.
+func (d *DockerNetwork) Check() bool {
+	return len(d.Collect()) > 0
+}
+
+// Charts returns the charts that we want to expose to the agent.
+func (d *DockerNetwork) Charts() *module.Charts {
+	return d.charts
+}
+
+// Collect will collect the metrics from the docker client.
+func (d *DockerNetwork) Collect() map[string]int64 {
+	// All we'll be collecting is the current bit rate of the network interface.
+	// This does mean we need to store a previous value, so we can calculate the difference.
+	mx, err := d.collect() // TODO: Implement collect
+	if err != nil {
+		d.Error(err)
+	}
+
+	if len(mx) == 0 {
+		return nil
+	}
+	return mx
+}
+
+// Cleanup will close our docker client.s
+func (d *DockerNetwork) Cleanup() {
+	if d.client == nil {
+		return
+	}
+	if err := d.client.Close(); err != nil {
+		d.Warningf("error on closing docker client: %v", err)
+	}
+	d.client = nil
+}

--- a/modules/docker_network/docker_network.go
+++ b/modules/docker_network/docker_network.go
@@ -36,13 +36,15 @@ func New() *DockerNetwork {
 		newClient: func(cfg Config) (dockerClient, error) {
 			return docker.NewClientWithOpts(docker.WithHost(cfg.Address))
 		},
-		containers: make(map[string]bool),
+		containers:    make(map[string]bool),
+		previousStats: make(map[string]types.StatsJSON),
 	}
 }
 
 type Config struct {
-	Timeout web.Duration `yaml:"timeout"`
-	Address string       `yaml:"address"`
+	Timeout     web.Duration `yaml:"timeout"`
+	Address     string       `yaml:"address"`
+	UpdateEvery int          `yaml:"update_every"`
 }
 
 type (
@@ -80,7 +82,7 @@ func (d *DockerNetwork) Init() bool {
 
 // Check will check if the module is able to collect metrics.
 func (d *DockerNetwork) Check() bool {
-	return len(d.Collect()) > 0
+	return true
 }
 
 // Charts returns the charts that we want to expose to the agent.

--- a/modules/docker_network/docker_network.go
+++ b/modules/docker_network/docker_network.go
@@ -29,7 +29,7 @@ func New() *DockerNetwork {
 			Address: docker.DefaultDockerHost,
 			Timeout: web.Duration{Duration: time.Second * 5},
 		},
-		charts: summaryCharts.Copy(), // TODO: Implement summaryCharts
+		charts: summaryCharts.Copy(),
 		newClient: func(cfg Config) (dockerClient, error) {
 			return docker.NewClientWithOpts(docker.WithHost(cfg.Address))
 		},
@@ -62,7 +62,7 @@ type (
 		Info(ctx context.Context) (types.Info, error)
 		// We just need a list of containers and the stats about it
 		ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
-		// TODO: Implement container stats
+		ContainerStats(ctx context.Context, containerID string, stream bool) (types.ContainerStats, error)
 		Close() error
 	}
 )
@@ -88,7 +88,7 @@ func (d *DockerNetwork) Charts() *module.Charts {
 func (d *DockerNetwork) Collect() map[string]int64 {
 	// All we'll be collecting is the current bit rate of the network interface.
 	// This does mean we need to store a previous value, so we can calculate the difference.
-	mx, err := d.collect() // TODO: Implement collect
+	mx, err := d.collect()
 	if err != nil {
 		d.Error(err)
 	}

--- a/modules/docker_network/docker_network.go
+++ b/modules/docker_network/docker_network.go
@@ -17,7 +17,10 @@ var configSchema string
 func init() {
 	module.Register("docker_network", module.Creator{
 		JobConfigSchema: configSchema,
-		Create:          func() module.Module { return New() },
+		Defaults: module.Defaults{
+			UpdateEvery: 10,
+		},
+		Create: func() module.Module { return New() },
 	})
 }
 
@@ -53,7 +56,8 @@ type (
 		client        dockerClient
 		verNegotiated bool
 
-		containers map[string]bool
+		containers    map[string]bool
+		previousStats map[string]types.StatsJSON
 	}
 	// For our docker client, we use the official docker client library.
 	// We embed the client in our module, so we can easily mock it in our tests.

--- a/modules/docker_network/docker_network_test.go
+++ b/modules/docker_network/docker_network_test.go
@@ -1,0 +1,1 @@
+package docker_network

--- a/modules/init.go
+++ b/modules/init.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/netdata/go.d.plugin/modules/dnsquery"
 	_ "github.com/netdata/go.d.plugin/modules/docker"
 	_ "github.com/netdata/go.d.plugin/modules/docker_engine"
+	_ "github.com/netdata/go.d.plugin/modules/docker_network"
 	_ "github.com/netdata/go.d.plugin/modules/dockerhub"
 	_ "github.com/netdata/go.d.plugin/modules/elasticsearch"
 	_ "github.com/netdata/go.d.plugin/modules/energid"


### PR DESCRIPTION
Adds a plugin for collecting docker container networking stats. This pulls directly from docker so it will work with macvlans. 